### PR TITLE
go mod init ,,,, go build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go_microservice
+
+go 1.20


### PR DESCRIPTION
so basically when tried to run main.go
got an error --- saying handlers package is not in goroot
so did (go build) to build that package into goroot but failed as no module manager
so did (go mod init) --- equivalent to (npm init)
then module package was initialised
did (go build) -- worked out
now (go run main.go) was able to run as we built package in goroot